### PR TITLE
Return error on unknown flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,6 +29,11 @@ func main() {
 	)
 	flag.Parse()
 
+	if flag.NArg() > 0 {
+		slog.Error("Unknown flags provided", "flags", flag.Args())
+		os.Exit(1)
+	}
+
 	if *printVersion {
 		fmt.Println(Version) //nolint
 		return


### PR DESCRIPTION
Technically this is a breaking change. But not returning an error on unknown flags is a bug. Therefore, still considering this a bugfix.